### PR TITLE
Fix/main allocation

### DIFF
--- a/compilador/tests/unit_tests.py
+++ b/compilador/tests/unit_tests.py
@@ -514,7 +514,6 @@ class TestVirtualMachine(unittest.TestCase):
     def test_insert_symbol_in_segment(self):
         ft = FunctionTable()
         vt = VariableTable()
-        ft.set_function("func", "void", [], vt)
         ft.set_function("main", "void", [], vt)
 
         vm = VirtualMachine(7, 7, 7, ft)
@@ -528,14 +527,13 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(vm.insert_symbol_in_segment("Global Segment", a_flt), True)
         self.assertEqual(vm.insert_symbol_in_segment("Global Segment", b_flt), False)
 
-        self.assertEqual(vm.insert_symbol_in_segment("func", a_frg), True)
-        self.assertEqual(vm.insert_symbol_in_segment("func", b_frg), False)
+        self.assertEqual(vm.insert_symbol_in_segment("main", a_frg), True)
+        self.assertEqual(vm.insert_symbol_in_segment("main", b_frg), False)
 
     def test_get_direction_symbol(self):
         ft = FunctionTable()
         vt = VariableTable()
         ft.set_function("func1", "void", [], vt)
-        ft.set_function("func2", "void", [], vt)
         ft.set_function("main", "void", [], vt)
 
         a_int = Symbol("A", "INT")
@@ -568,6 +566,14 @@ class TestVirtualMachine(unittest.TestCase):
         small_vm.insert_symbol_in_segment("Constant Segment", g_frog)
 
         # Inserting in Local segment
+        small_vm.insert_symbol_in_segment("main", a_int)
+        small_vm.insert_symbol_in_segment("main", b_flt)
+        small_vm.insert_symbol_in_segment("main", c_str)
+        small_vm.insert_symbol_in_segment("main", d_char)
+        small_vm.insert_symbol_in_segment("main", e_bool)
+        small_vm.insert_symbol_in_segment("main", f_null)
+        small_vm.insert_symbol_in_segment("main", g_frog)
+
         small_vm.insert_symbol_in_segment("func1", a_int)
         small_vm.insert_symbol_in_segment("func1", b_flt)
         small_vm.insert_symbol_in_segment("func1", c_str)
@@ -575,14 +581,6 @@ class TestVirtualMachine(unittest.TestCase):
         small_vm.insert_symbol_in_segment("func1", e_bool)
         small_vm.insert_symbol_in_segment("func1", f_null)
         small_vm.insert_symbol_in_segment("func1", g_frog)
-
-        small_vm.insert_symbol_in_segment("func2", a_int)
-        small_vm.insert_symbol_in_segment("func2", b_flt)
-        small_vm.insert_symbol_in_segment("func2", c_str)
-        small_vm.insert_symbol_in_segment("func2", d_char)
-        small_vm.insert_symbol_in_segment("func2", e_bool)
-        small_vm.insert_symbol_in_segment("func2", f_null)
-        small_vm.insert_symbol_in_segment("func2", g_frog)
 
         # Searching in Global segment
         self.assertEqual(small_vm.get_direction_symbol(0), a_int)
@@ -641,6 +639,14 @@ class TestVirtualMachine(unittest.TestCase):
         real_vm.insert_symbol_in_segment("Constant Segment", g_frog)
 
         # Inserting in Local segment
+        real_vm.insert_symbol_in_segment("main", a_int)
+        real_vm.insert_symbol_in_segment("main", b_flt)
+        real_vm.insert_symbol_in_segment("main", c_str)
+        real_vm.insert_symbol_in_segment("main", d_char)
+        real_vm.insert_symbol_in_segment("main", e_bool)
+        real_vm.insert_symbol_in_segment("main", f_null)
+        real_vm.insert_symbol_in_segment("main", g_frog)
+
         real_vm.insert_symbol_in_segment("func1", a_int)
         real_vm.insert_symbol_in_segment("func1", b_flt)
         real_vm.insert_symbol_in_segment("func1", c_str)
@@ -648,14 +654,6 @@ class TestVirtualMachine(unittest.TestCase):
         real_vm.insert_symbol_in_segment("func1", e_bool)
         real_vm.insert_symbol_in_segment("func1", f_null)
         real_vm.insert_symbol_in_segment("func1", g_frog)
-
-        real_vm.insert_symbol_in_segment("func2", a_int)
-        real_vm.insert_symbol_in_segment("func2", b_flt)
-        real_vm.insert_symbol_in_segment("func2", c_str)
-        real_vm.insert_symbol_in_segment("func2", d_char)
-        real_vm.insert_symbol_in_segment("func2", e_bool)
-        real_vm.insert_symbol_in_segment("func2", f_null)
-        real_vm.insert_symbol_in_segment("func2", g_frog)
 
         # Searching in Global segment
         self.assertEqual(real_vm.get_direction_symbol(0), a_int)

--- a/compilador/vm/virtual_machine.py
+++ b/compilador/vm/virtual_machine.py
@@ -35,7 +35,7 @@ class VirtualMachine(object):
         local_size,
         local_start_direction,
     ):
-        num_local_segments = len(self.func_table.functions) - 1
+        num_local_segments = len(self.func_table.functions)
         if not num_local_segments:
             return []
 
@@ -46,11 +46,10 @@ class VirtualMachine(object):
 
         segments = []
         for func_name in self.func_table.functions:
-            if func_name != "main":
-                segments.append(
-                    MemorySegment(func_name, local_segment_size, start_direction)
-                )
-                start_direction += local_memory_size
+            segments.append(
+                MemorySegment(func_name, local_segment_size, start_direction)
+            )
+            start_direction += local_memory_size
 
         return segments
 


### PR DESCRIPTION
[SuperCompi - #55](https://trello.com/c/h6fiHPSC/55-el-main-no-guarda-variables)

## Descripción
Ahora el main guarda variables en segmentos de memoria
## Checklist
* [x] El código funciona
* [x] Se añadieron pruebas
* [x] Las pruebas pasan
* [x] El codigo pasó por el estilizador de código